### PR TITLE
Broken callback context

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ If module loading is disabled, you'll get this error when you try to run `.load 
 ```
 Error: unknown command or invalid arguments:  "load". Enter ".help" for help
 ```
+
+### Useful references
+
+* <https://www.sqlite.org/src/file/ext/misc/series.c>
+* <https://www.sqlite.org/capi3ref.html#sqlite3_auto_extension>
+* <https://doc.rust-lang.org/nomicon/ffi.html>
+* <https://rust-lang.github.io/rust-bindgen/print.html>
+* <https://doc.rust-lang.org/1.30.0/book/second-edition/ch19-01-unsafe-rust.html>
+* <https://github.com/rust-lang/rust-bindgen/blob/master/book/src/whitelisting.md>
+* <https://github.com/cloudmeter/sqlite/blob/master/sqlite3ext.h>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Anti-pitch
 
-Anything you could do by running shell commands from SQLite, you could do by piping the output of those commands to SQLite using the incredibly [q](http://harelba.github.io/q/) library. You probably want that instead.
+Anything you could do by running shell commands from SQLite, you could do by piping the output of those commands to SQLite using the incredible [q](http://harelba.github.io/q/) tool. You probably want that instead.
 
 ## Remaining work
 

--- a/basque.rs
+++ b/basque.rs
@@ -7,7 +7,23 @@ use std::ffi::CString;
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 extern crate libc;
-use libc::{c_int, c_void, c_char};
+use libc::{c_void, c_char};
+
+#[no_mangle]
+extern fn basque_cmd(ctx: *mut sqlite3_context,
+                     argc: ::std::os::raw::c_int,
+                     argv: *mut *mut sqlite3_value) {
+    println!("basque_cmd called with {} args", argc);
+    let internal_state: Box<Box<InternalState>> = unsafe { Box::from_raw(ctx as *mut Box<InternalState>) };
+    // Was hoping for 69. Get "1" or other random numbers,
+    // so I'm grabbing the wrong memory somehow.
+    println!("magic value from context is: {}", internal_state.magic);
+}
+
+struct InternalState {
+    api: *const sqlite3_api_routines,
+    magic: u32
+}
 
 // https://www.sqlite.org/loadext.html
 // int sqlite3_extension_init(
@@ -28,13 +44,24 @@ use libc::{c_int, c_void, c_char};
 // }
 
 #[no_mangle]
-pub unsafe extern fn sqlite3_basque_init(db: *const c_void, err: *mut *const c_char, routines: *const sqlite3_api_routines) -> c_int {
+pub unsafe extern fn sqlite3_basque_init(db: *mut sqlite3, err: *mut *const c_char, routines: *const sqlite3_api_routines) -> u32 {
     let msg = CString::new("Not yet implemented!").expect("Failed to allocate error");
-    //let msg_ptr = msg.as_ptr();
-    println!("String is in {:p}", (*routines).mprintf.unwrap());
     let msg_ptr: *const c_char = ((*routines).mprintf.unwrap())(msg.as_ptr());
-    println!("sqlite fmt is at {:p}", msg_ptr);
     std::mem::forget(msg);
     *err = msg_ptr;
-    return 1;
+
+    // We need to keep a reference to `routines` to call sqlite's API later (we're not
+    // allowed to link to it, since we need the version that loaded us as a library.)
+    // SQLite recommends you do this using a macro called SQLITE_EXTENSION_INIT2,
+    // which stuffs the pointer into a static. I'd rather keep it inside our
+    // callback context so we can avoid a global.
+    let internal_state = Box::new(Box::new(InternalState { api: routines, magic: 69 }));
+
+    let fn_name = CString::new("basque_cmd").expect("Failed to allocate name");
+
+    ((*routines).create_function.unwrap())(db, fn_name.as_ptr(), 1, SQLITE_UTF8 as i32,
+                                           Box::into_raw(internal_state) as *mut c_void,
+                                           Some(basque_cmd), None, None);
+
+    return SQLITE_OK;
 }

--- a/basque.rs
+++ b/basque.rs
@@ -10,11 +10,12 @@ extern crate libc;
 use libc::{c_void, c_char};
 
 #[no_mangle]
-extern fn basque_cmd(ctx: *mut sqlite3_context,
+unsafe extern fn basque_cmd(ctx: *mut sqlite3_context,
                      argc: ::std::os::raw::c_int,
                      argv: *mut *mut sqlite3_value) {
-    println!("basque_cmd called with {} args", argc);
-    let internal_state: Box<Box<InternalState>> = unsafe { Box::from_raw(ctx as *mut Box<InternalState>) };
+    let state_ptr = ((*global_routines).user_data.unwrap())(ctx);
+    println!("basque_cmd called with {} args and context: {:p}", argc, state_ptr);
+    let internal_state: Box<Box<InternalState>> = unsafe { Box::from_raw(state_ptr as *mut Box<InternalState>) };
     // Was hoping for 69. Get "1" or other random numbers,
     // so I'm grabbing the wrong memory somehow.
     println!("magic value from context is: {}", internal_state.magic);
@@ -43,6 +44,10 @@ struct InternalState {
 //   return rc;
 // }
 
+// rot13 example extension: https://www.sqlite.org/src/file/ext/misc/rot13.c
+
+static mut global_routines: *const sqlite3_api_routines = 0 as *const sqlite3_api_routines;
+
 #[no_mangle]
 pub unsafe extern fn sqlite3_basque_init(db: *mut sqlite3, err: *mut *const c_char, routines: *const sqlite3_api_routines) -> u32 {
     let msg = CString::new("Not yet implemented!").expect("Failed to allocate error");
@@ -50,17 +55,20 @@ pub unsafe extern fn sqlite3_basque_init(db: *mut sqlite3, err: *mut *const c_ch
     std::mem::forget(msg);
     *err = msg_ptr;
 
+    global_routines = routines;
     // We need to keep a reference to `routines` to call sqlite's API later (we're not
     // allowed to link to it, since we need the version that loaded us as a library.)
     // SQLite recommends you do this using a macro called SQLITE_EXTENSION_INIT2,
     // which stuffs the pointer into a static. I'd rather keep it inside our
     // callback context so we can avoid a global.
     let internal_state = Box::new(Box::new(InternalState { api: routines, magic: 69 }));
+    let internal_state_ptr = Box::into_raw(internal_state);
+    println!("raw context pointer: {:p}", internal_state_ptr);
 
     let fn_name = CString::new("basque_cmd").expect("Failed to allocate name");
 
     ((*routines).create_function.unwrap())(db, fn_name.as_ptr(), 1, SQLITE_UTF8 as i32,
-                                           Box::into_raw(internal_state) as *mut c_void,
+                                           internal_state_ptr as *mut c_void,
                                            Some(basque_cmd), None, None);
 
     return SQLITE_OK;

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,8 @@ fn main() {
     // the resulting bindings.
     let bindings = bindgen::Builder::default()
         .whitelist_type("sqlite3_api_routines")
+        .whitelist_var("SQLITE_UTF8")
+        .whitelist_var("SQLITE_OK")
         .rustfmt_bindings(true)
         .with_rustfmt(PathBuf::from("/Users/phil/.cargo/bin/rustfmt"))
         // The input header we would like to generate

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-echo '.load ./target/debug/libbasque' | sqlite3
+echo '.read test.sql' | sqlite3

--- a/test.sql
+++ b/test.sql
@@ -1,0 +1,2 @@
+.load ./target/debug/libbasque
+select basque_cmd("asdf");


### PR DESCRIPTION
I've got this to where the custom SQLite function is registered, and it gets called back by SQLite. Great! 🎉 

Unfortunately, to do anything useful in the callback, we need to be able to call builtin SQLite functions. These live in the `sqlite3_api_routines` struct passed to `_init` and we need to keep a reference to that struct inside our callback context, since it _isn't_ passed to the callback. (SQLite's docs just tell you to stick it in a static/global.)

I'm not setting or reading the `Box`ed context correctly, but don't understand what Rust is doing enough to fix it yet.

Actual results:

```
./test.sh
+ echo '.read test.sql'
+ sqlite3
basque_cmd called with 1 args
magic value from context is: 1
sqlite3(97362,0x10eed95c0) malloc: *** error for object 0x7ff0a601e870: pointer being freed was not allocated
sqlite3(97362,0x10eed95c0) malloc: *** set a breakpoint in malloc_error_break to debug
./test.sh: line 5: 97361 Done                    echo '.read test.sql'
     97362 Abort trap: 6           | sqlite3
```

Desired results:
```
./test.sh
+ echo '.read test.sql'
+ sqlite3
basque_cmd called with 1 args
magic value from context is: 69
```