### PR TITLE
Keep internal state in memory until finalization

### DIFF
--- a/test.sql
+++ b/test.sql
@@ -1,2 +1,3 @@
 .load ./target/debug/libbasque
 select basque_cmd("asdf");
+select basque_cmd("asdf");


### PR DESCRIPTION
This keeps us from crashing on the section invocation, but also remembers to clean up our `InternalState` struct on finalization. Wow.